### PR TITLE
feat: replace ref-param in mongo query

### DIFF
--- a/lib/parser.ex
+++ b/lib/parser.ex
@@ -1,9 +1,9 @@
 defmodule QueryParser.Parser do
   @moduledoc """
-    This Parser module will use the grammar to parse the query string into an AST.
+  This Parser module will use the grammar to parse the query string into an AST.
   """
-  alias QueryParser.Errors.BusinessError
   alias LenraCommon.Errors.DevError
+  alias QueryParser.Errors.BusinessError
   alias QueryParser.Parser.Grammar
 
   # Sadly, the warning in the grammar file do propagate with these function.
@@ -56,6 +56,15 @@ defmodule QueryParser.Parser do
 
   @param_regex ~r/^@(?!@)[a-zA-Z_$][a-zA-Z_$0-9]*(\.[a-zA-Z_$][a-zA-Z_$0-9]*)*$/
 
+  @doc """
+    This function will take a valid mongo query and replace all param-ref (@foo.bar)
+    to replace them with the corresponding value in the params map.
+
+    ex:
+    > Parser.replace_params(%{"foo" => "@me"}, %{"me" => "bar"})
+    %{"foo" => "bar"}
+  """
+  @spec replace_params(term(), map()) :: term()
   def replace_params(map, params) when is_map(map) and is_map(params) do
     map
     |> Enum.map(fn {k, v} -> {k, replace_params(v, params)} end)

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -919,6 +919,13 @@ defmodule QueryParser.ParserTest do
       assert %{"foo" => "bar"} = Parser.replace_params(%{"foo" => "@me"}, %{"me" => "bar"})
     end
 
+    test "base param in a list" do
+      assert %{"foo" => ["bar"]} = Parser.replace_params(%{"foo" => ["@me"]}, %{"me" => "bar"})
+
+      assert %{"foo" => [%{"bar" => "baz"}]} =
+               Parser.replace_params(%{"foo" => [%{"bar" => "@me"}]}, %{"me" => "baz"})
+    end
+
     test "path param in a map" do
       assert %{"foo" => "bar"} =
                Parser.replace_params(%{"foo" => "@me.stuff"}, %{"me" => %{"stuff" => "bar"}})


### PR DESCRIPTION
## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I did not include breaking changes
- [x] I included unit tests that cover my changes
- [x] I added/updated the documentation about my changes
- [x] I made my own code-review before requesting one

## Description of the changes
I added the function to replace the @param_refs from a mongo query that will be run directly to mongo.
